### PR TITLE
test(service): update service unit tests to assert custom exceptions

### DIFF
--- a/backend/src/test/java/com/librarymanager/backend/service/BookCatalogServiceTest.java
+++ b/backend/src/test/java/com/librarymanager/backend/service/BookCatalogServiceTest.java
@@ -2,6 +2,9 @@ package com.librarymanager.backend.service;
 
 import com.librarymanager.backend.entity.Book;
 import com.librarymanager.backend.entity.BookGenre;
+import com.librarymanager.backend.exception.BusinessRuleViolationException;
+import com.librarymanager.backend.exception.DuplicateResourceException;
+import com.librarymanager.backend.exception.ResourceNotFoundException;
 import com.librarymanager.backend.repository.BookRepository;
 import com.librarymanager.backend.testutil.TestDataFactory;
 
@@ -100,7 +103,7 @@ class BookCatalogServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> bookCatalogService.createBook(validBook))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(DuplicateResourceException.class)
             .hasMessageContaining("Book with ISBN 978-0134685991 already exists");
 
         verify(bookRepository).findByIsbn(validBook.getIsbn());
@@ -119,7 +122,7 @@ class BookCatalogServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> bookCatalogService.createBook(invalidBook))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(BusinessRuleViolationException.class)
             .hasMessageContaining("Total copies must be at least 1");
 
         verify(bookRepository, never()).save(any());
@@ -155,8 +158,8 @@ class BookCatalogServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> bookCatalogService.updateBook(validBook))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Book with ID 999 does not exist");
+            .isInstanceOf(ResourceNotFoundException.class)
+            .hasMessageContaining("Book with ID 999 not found");
 
         verify(bookRepository).findById(999L);
         verify(bookRepository, never()).save(any());
@@ -190,8 +193,8 @@ class BookCatalogServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> bookCatalogService.deleteBook(bookId))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("Cannot delete book with borrowed copies");
+            .isInstanceOf(BusinessRuleViolationException.class)
+            .hasMessageContaining("Cannot delete book '" + bookWithBorrowedCopies.getTitle() + "'");
 
         verify(bookRepository).findById(bookId);
         verify(bookRepository, never()).deleteById(any());

--- a/backend/src/test/java/com/librarymanager/backend/service/UserServiceTest.java
+++ b/backend/src/test/java/com/librarymanager/backend/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.librarymanager.backend.entity.User;
 import com.librarymanager.backend.entity.UserRole;
 import com.librarymanager.backend.repository.UserRepository;
 import com.librarymanager.backend.testutil.TestDataFactory;
+import com.librarymanager.backend.exception.ResourceNotFoundException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -75,11 +76,11 @@ class UserServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
 
         // When
-        Optional<User> result = userService.findById(userId);
+        User result = userService.findById(userId);
 
         // Then
-        assertThat(result).isPresent();
-        assertThat(result.get().getEmail()).isEqualTo("john.doe@example.com");
+        assertThat(result).isNotNull();
+        assertThat(result.getEmail()).isEqualTo("john.doe@example.com");
         verify(userRepository).findById(userId);
     }
 
@@ -90,11 +91,10 @@ class UserServiceTest {
         Long userId = 999L;
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        // When
-        Optional<User> result = userService.findById(userId);
-
-        // Then
-        assertThat(result).isEmpty();
+        // When & Then
+        assertThatThrownBy(() -> userService.findById(userId))
+            .isInstanceOf(ResourceNotFoundException.class)
+            .hasMessageContaining("User with ID 999 not found");
         verify(userRepository).findById(userId);
     }
 
@@ -165,8 +165,8 @@ class UserServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> userService.updateUser(testUser))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("User with ID 999 does not exist");
+            .isInstanceOf(ResourceNotFoundException.class)
+            .hasMessageContaining("User with ID 999 not found");
 
         verify(userRepository).existsById(999L);
         verify(userRepository, never()).save(any());


### PR DESCRIPTION
## Context
After introducing custom exceptions across the service layer, the unit tests needed to be updated to assert these new exception types instead of relying on generic ones. This ensures test coverage is aligned with the new error-handling strategy and validates that services correctly enforce business rules through domain-specific exceptions.

## Changes
- **UserServiceTest**
  - Added assertions for `ResourceNotFoundException` when users are missing.  

- **InventoryServiceTest**
  - Applied `ResourceNotFoundException` for missing book scenarios.  
  - Applied `BusinessRuleViolationException` for unavailable books or invalid return attempts.  

- **BookCatalogServiceTest**
  - Added `DuplicateResourceException` assertions for duplicate ISBNs.  
  - Added `ResourceNotFoundException` for missing books.  
  - Added `BusinessRuleViolationException` for invalid copy counts and deletion rules.  

- Validated exception messages in all cases for consistency and clarity.  

## Rationale
- **Accuracy**: Tests now reflect the actual domain-specific exceptions thrown by the services.  
- **Maintainability**: Reduces reliance on generic exception checks, making tests more descriptive and aligned with business logic.  
- **Consistency**: Ensures that all exception scenarios are covered and validated across services.  

## Testing Notes
- Verified that each exception is correctly thrown under invalid scenarios.  
- Checked that error messages match expected values to guarantee consistency in API responses.  
