### PR TITLE
feat(auth): add authentication guards and interceptor for route protection

### DIFF
--- a/frontend/src/app/auth/auth.interceptor.ts
+++ b/frontend/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,17 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = localStorage.getItem('auth_token');
+  const isPublic = req.url.includes('/api/auth/login') || req.url.includes('/api/auth/register');
+
+  if (token && !isPublic) {
+    const cloned = req.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return next(cloned);
+  }
+
+  return next(req);
+};

--- a/frontend/src/app/auth/guards/admin.guard.spec.ts
+++ b/frontend/src/app/auth/guards/admin.guard.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { adminGuard } from './admin.guard';
+import { AuthService } from '../auth.service';
+
+const MSG_LOGIN_REQUIRED = 'Please login to access this page';
+const MSG_ACCESS_DENIED = 'Access denied. Admin privileges required';
+const SNACKBAR_ACTION = 'Close';
+const SNACKBAR_CONFIG = { duration: 3000 } as const;
+const URL_TO_NAVIGATE = '/dashboard';
+
+describe('adminGuard', () => {
+  let mockAuthService: jasmine.SpyObj<AuthService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockSnackBar: jasmine.SpyObj<MatSnackBar>;
+
+  beforeEach(() => {
+    mockAuthService = jasmine.createSpyObj('AuthService', ['isLoggedIn', 'getUserRole']);
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockSnackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: Router, useValue: mockRouter },
+        { provide: MatSnackBar, useValue: mockSnackBar },
+      ],
+    });
+  });
+
+  it('should return false and redirect to login when user is not logged in', () => {
+    mockAuthService.isLoggedIn.and.returnValue(false);
+
+    const result = TestBed.runInInjectionContext(() => adminGuard({} as any, {} as any));
+
+    expect(result).toBeFalse();
+    expect(mockAuthService.isLoggedIn).toHaveBeenCalled();
+    expect(mockAuthService.getUserRole).not.toHaveBeenCalled();
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      MSG_LOGIN_REQUIRED,
+      SNACKBAR_ACTION,
+      SNACKBAR_CONFIG
+    );
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('should return true when user is logged in as ADMIN', () => {
+    mockAuthService.isLoggedIn.and.returnValue(true);
+    mockAuthService.getUserRole.and.returnValue('ADMIN');
+
+    const result = TestBed.runInInjectionContext(() => adminGuard({} as any, {} as any));
+
+    expect(result).toBeTrue();
+    expect(mockAuthService.isLoggedIn).toHaveBeenCalled();
+    expect(mockAuthService.getUserRole).toHaveBeenCalled();
+    expect(mockSnackBar.open).not.toHaveBeenCalled();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should return false and redirect to dashboard when user is MEMBER', () => {
+    mockAuthService.isLoggedIn.and.returnValue(true);
+    mockAuthService.getUserRole.and.returnValue('MEMBER');
+
+    const result = TestBed.runInInjectionContext(() => adminGuard({} as any, {} as any));
+
+    expect(result).toBeFalse();
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      MSG_ACCESS_DENIED,
+      SNACKBAR_ACTION,
+      SNACKBAR_CONFIG
+    );
+    expect(mockRouter.navigate).toHaveBeenCalledWith([URL_TO_NAVIGATE]);
+  });
+
+  it('should return false and redirect to dashboard when role is null', () => {
+    mockAuthService.isLoggedIn.and.returnValue(true);
+    mockAuthService.getUserRole.and.returnValue(null);
+
+    const result = TestBed.runInInjectionContext(() => adminGuard({} as any, {} as any));
+
+    expect(result).toBeFalse();
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      MSG_ACCESS_DENIED,
+      SNACKBAR_ACTION,
+      SNACKBAR_CONFIG
+    );
+    expect(mockRouter.navigate).toHaveBeenCalledWith([URL_TO_NAVIGATE]);
+  });
+
+  it('should return false and redirect to dashboard when role is undefined', () => {
+    mockAuthService.isLoggedIn.and.returnValue(true);
+    mockAuthService.getUserRole.and.returnValue(undefined as unknown as string);
+
+    const result = TestBed.runInInjectionContext(() => adminGuard({} as any, {} as any));
+
+    expect(result).toBeFalse();
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      MSG_ACCESS_DENIED,
+      SNACKBAR_ACTION,
+      SNACKBAR_CONFIG
+    );
+    expect(mockRouter.navigate).toHaveBeenCalledWith([URL_TO_NAVIGATE]);
+  });
+});

--- a/frontend/src/app/auth/guards/admin.guard.ts
+++ b/frontend/src/app/auth/guards/admin.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivateFn } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+
+export const adminGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  const snackBar = inject(MatSnackBar);
+
+  if (!authService.isLoggedIn()) {
+    snackBar.open('Please login to access this page', 'Close', { duration: 3000 });
+    router.navigate(['/login']);
+    return false;
+  }
+
+  if (authService.getUserRole() === 'ADMIN') {
+    return true;
+  } else {
+    snackBar.open('Access denied. Admin privileges required', 'Close', { duration: 3000 });
+    router.navigate(['/dashboard']);
+    return false;
+  }
+};

--- a/frontend/src/app/auth/guards/auth.guard.spec.ts
+++ b/frontend/src/app/auth/guards/auth.guard.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { authGuard } from './auth.guard';
+import { AuthService } from '../auth.service';
+
+const MSG_LOGIN_REQUIRED = 'Please login to access this page';
+const SNACKBAR_ACTION = 'Close';
+const SNACKBAR_CONFIG = { duration: 3000 } as const;
+
+describe('authGuard', () => {
+  let mockAuthService: jasmine.SpyObj<AuthService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockSnackBar: jasmine.SpyObj<MatSnackBar>;
+
+  beforeEach(() => {
+    mockAuthService = jasmine.createSpyObj('AuthService', ['isLoggedIn', 'getUserRole']);
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockSnackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: Router, useValue: mockRouter },
+        { provide: MatSnackBar, useValue: mockSnackBar },
+      ],
+    });
+  });
+
+  it('should return true when user is logged in', () => {
+    mockAuthService.isLoggedIn.and.returnValue(true);
+
+    const result = TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
+
+    expect(result).toBeTrue();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(mockSnackBar.open).not.toHaveBeenCalled();
+  });
+
+  it('should return false when user is not logged in', () => {
+    mockAuthService.isLoggedIn.and.returnValue(false);
+
+    const result = TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
+
+    expect(result).toBeFalse();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      MSG_LOGIN_REQUIRED,
+      SNACKBAR_ACTION,
+      SNACKBAR_CONFIG
+    );
+  });
+
+  it('should not call router or snackbar when logged in', () => {
+    mockAuthService.isLoggedIn.and.returnValue(true);
+
+    void TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
+
+    expect(mockAuthService.isLoggedIn).toHaveBeenCalledTimes(1);
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(mockSnackBar.open).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/auth/guards/auth.guard.ts
+++ b/frontend/src/app/auth/guards/auth.guard.ts
@@ -1,0 +1,20 @@
+import { CanActivateFn } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  const snackBar = inject(MatSnackBar);
+
+  if (authService.isLoggedIn()) {
+    return true;
+  } 
+
+  // If we reach here, user is not logged in
+  snackBar.open('Please login to access this page', 'Close', { duration: 3000 });
+  router.navigate(['/login']);
+  return false;
+}


### PR DESCRIPTION
### Summary

This pull request introduces authentication guards (`authGuard`, `adminGuard`) and an HTTP interceptor (`authInterceptor`) to enforce access control and secure API communication throughout the frontend application.

Together, these implementations complete the authorization layer of the authentication feature, ensuring that only authenticated and properly authorized users can access protected routes or send privileged requests.

### Testing

`authGuard.spec.ts`
- ✅ Returns true for logged-in users
- ✅ Returns false for unauthenticated users
- ✅ Verifies snackbar message and redirect behavior
- ✅ Ensures clean dependency injection (mocks for Router, MatSnackBar, and AuthService)

`adminGuard.spec.ts`
- ✅ Blocks navigation and redirects when not logged in
- ✅ Allows navigation for logged-in ADMIN users 
- ✅ Denies access and redirects for MEMBER role
- ✅ Handles null/undefined role edge cases gracefully
- ✅ Confirms correct snackbar and routing behavior

All tests utilize:
- Jasmine spies for all external dependencies
- TestBed.runInInjectionContext() to simulate Angular’s DI environment
- Constants for consistent snackbar configuration across specs

### 🧠 Design Considerations
- Functional guards & interceptors → Modern Angular 16+ design
- Single Responsibility → Guards handle navigation; service manages auth logic
- User feedback → Snackbars with clear, consistent messages
- Security awareness → Prevents unauthorized route and API access
- Maintainability → Minimal boilerplate, clear purpose, easy to extend for future roles